### PR TITLE
try catch for writeStagedState serialize

### DIFF
--- a/src/createPersistoid.js
+++ b/src/createPersistoid.js
@@ -101,9 +101,17 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
         delete stagedState[key]
       }
     })
-
+    let serializedState 
+    try {
+      serializedState = serialize(stagedState)
+    } catch (err) {
+        console.error(
+          'redux-persist/createPersistoid: error serializing state',
+          err
+        )
+    }
     writePromise = storage
-      .setItem(storageKey, serialize(stagedState))
+      .setItem(storageKey, serializedState)
       .catch(onWriteFail)
   }
 


### PR DESCRIPTION
Even though there was ".catch" on this line, it only caught errors from setItem, so an error from serialize would be completely unhandled.

This will at least give a more helpful error message than this raw error:
```
RangeError: Out of memory
  at stringify([native code])
  at writeStagedState(node_modules/redux-persist/lib/createPersistoid.js:90:48)
  at processNextKey(node_modules/redux-persist/lib/createPersistoid.js:78:7)
  at _callTimer(node_modules/react-native/Libraries/Core/Timers/JSTimers.js:130:7)
  at apply(node_modules/react-native/Libraries/Core/Timers/JSTimers.js:383:7)
  at __callFunction(node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js:416:27)
  at fn(node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js:109:12)
  at __guard(node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js:364:9)
  at value(node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js:108:10)
  at value([native code])
```